### PR TITLE
Add clarification for using `screen`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,13 @@ To submit a job to the `long` paratition, you need to add the following to your 
 
 # Using `screen` with the software modules
 
-If you for some reason wish to use `screen` as a virtual terminal/multiplexer on the servers, you should be aware that software loaded with `module load` will not immediately be available in your `screen` sessions. There is an easy solution for this. After you start your `screen` session, you can run `module reload` and all your loaded software will be available in that screen session.
+If you for some reason wish to use `screen` as a virtual terminal/multiplexer on
+the servers, you should be aware that software loaded with `module load` will
+not immediately be available in your `screen` sessions. There is an easy
+solution for this. After you start a new `screen` window, you can run `module
+reload` and all your loaded software will be available in that `screen`
+window. Note that you have to run `module reload` in every new `screen` window,
+even within the same `screen` session.
 
 
 # Linux terminal servers


### PR DESCRIPTION
It can apparently give problems to not run `module reload` in every `screen` window.